### PR TITLE
add a new grinbox error: offline

### DIFF
--- a/grinrelaylib/src/types/grinbox_response.rs
+++ b/grinrelaylib/src/types/grinbox_response.rs
@@ -16,6 +16,8 @@ pub enum GrinboxError {
 	TooManySubscriptions,
 	#[fail(display = "GrinboxError: invalid abbreviation relay address")]
 	InvalidRelayAbbr,
+	#[fail(display = "GrinboxError: not online")]
+	Offline,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -270,7 +270,7 @@ impl AsyncServer {
 			let relay_addr = lookup.get(&abbr).unwrap().clone();
 			GrinboxResponse::RelayAddr { abbr, relay_addr }
 		} else {
-			AsyncServer::error(GrinboxError::InvalidRelayAbbr)
+			AsyncServer::error(GrinboxError::Offline)
 		}
 	}
 


### PR DESCRIPTION
it's used for error which remote side is not online, when query it by abbreviated address (6-code).